### PR TITLE
Fix for IE's classList.toggle only supporting 1 parameter, add bower_components .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/paper-progress.html
+++ b/paper-progress.html
@@ -172,7 +172,7 @@ To change the progress bar background color:
     _toggleIndeterminate: function() {
       // If we use attribute/class binding, the animation sometimes doesn't translate properly
       // on Safari 7.1. So instead, we toggle the class here in the update method.
-      this.$.activeProgress.classList.toggle('indeterminate', this.indeterminate);
+      this.toggleClass('indeterminate', this.indeterminate, this.$.activeProgress);
     },
 
     _transformProgress: function(progress, ratio) {


### PR DESCRIPTION
Internet <s>Exploder</s> Explorer has an incomplete implementation of `classList.toggle`, in that it only accepts one parameter - the name of the class. Hence, when displaying any page with a `<paper-progress>` element, the element would start off in `indeterminate` mode, and any change to the `indeterminate` property would simply toggle the mode on and off without regard to the property's value. I've rewritten the `_toggleIndeterminate` function to use `toggleClass` from the Polymer core, which handles the second boolean parameter and thus fixes the bug.

Also, I noticed `.gitignore` was missing, so I threw one in.
