### PR TITLE
Remove unnecessary import

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.0.0",
     "iron-range-behavior": "PolymerElements/iron-range-behavior#^1.0.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0"
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/paper-progress.html
+++ b/paper-progress.html
@@ -9,9 +9,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
-<link rel="import" href="../paper-styles/paper-styles-classes.html">
 <link rel="import" href="../iron-range-behavior/iron-range-behavior.html">
+<link rel="import" href="../paper-styles/color.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 
 <!--
 The progress bars are for situations where the percentage completed can be


### PR DESCRIPTION
paper-progress does not use this import and it's throwing a warning in the console:
`/deep/ combinator is deprecated.`
- Also, iron-shadow-flex-layout.html is automatically imported from paper-styles. That will continue to throw the warning...
