### PR TITLE
Secondary progress should not be relative

### DIFF
--- a/paper-progress.html
+++ b/paper-progress.html
@@ -144,7 +144,6 @@ Custom property                               | Description                     
       }
 
       #secondaryProgress {
-        position: relative;
         background-color: var(--paper-progress-secondary-color, --google-green-100);
       }
 


### PR DESCRIPTION
I don't think this line should have been there ever but the latest `master` of `polymer` happens to give this priority over the earlier `--layout-fit` application and hence the secondary progress fails to display.
