### PR TITLE
Set aria-valuenow only if progress bar is determinate

### DIFF
--- a/paper-progress.html
+++ b/paper-progress.html
@@ -298,7 +298,6 @@ Custom property                               | Description                     
     },
 
     _toggleIndeterminate: function(indeterminate) {
-      this.indeterminate = indeterminate;
       // If we use attribute/class binding, the animation sometimes doesn't translate properly
       // on Safari 7.1. So instead, we toggle the class here in the update method.
       this.toggleClass('indeterminate', indeterminate, this.$.primaryProgress);

--- a/paper-progress.html
+++ b/paper-progress.html
@@ -298,9 +298,13 @@ Custom property                               | Description                     
     },
 
     _toggleIndeterminate: function(indeterminate) {
+      this.indeterminate = indeterminate;
       // If we use attribute/class binding, the animation sometimes doesn't translate properly
       // on Safari 7.1. So instead, we toggle the class here in the update method.
       this.toggleClass('indeterminate', indeterminate, this.$.primaryProgress);
+      if (this.indeterminate) {
+        this.removeAttribute('aria-valuenow');
+      }
     },
 
     _transformProgress: function(progress, ratio) {
@@ -325,7 +329,10 @@ Custom property                               | Description                     
 
       this.secondaryProgress = secondaryProgress;
 
-      this.setAttribute('aria-valuenow', value);
+      if (!this.indeterminate) {
+        this.setAttribute('aria-valuenow', value);
+      }
+
       this.setAttribute('aria-valuemin', min);
       this.setAttribute('aria-valuemax', max);
     },


### PR DESCRIPTION
According to the W3 Aria[0] spec --
"If the current value is not known (for example, an indeterminate progress bar), the author SHOULD NOT set the aria-valuenow attribute."

I couldn't find instructions to run the demo locally to double check, but the change seems straightforward enough.

[0] -- https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuenow
