### PR TITLE
Start position of the progress bar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-progress",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "http://polymer.github.io/LICENSE.txt",
   "description": "A material design progress bar",
   "authors": "The Polymer Authors",

--- a/demo/index.html
+++ b/demo/index.html
@@ -81,6 +81,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <paper-progress value="40" secondary-progress="80" class="blue"></paper-progress>
       </template>
     </demo-snippet>
+
+    <h3>It can represent a timeline</h3>
+    <demo-snippet class="centered-demo">
+      <template>
+        <style is="custom-style">
+          paper-progress.blue {
+            --paper-progress-active-color: var(--paper-light-blue-500);
+            --paper-progress-secondary-color: var(--paper-light-blue-100);
+          }
+
+          paper-progress.red {
+            --paper-progress-active-color: var(--paper-red-500);
+            --paper-progress-secondary-color: var(--paper-red-100);
+          }
+
+          paper-progress.green {
+            --paper-progress-active-color: var(--paper-light-green-500);
+            --paper-progress-secondary-color: var(--paper-light-green-100);
+          }
+        </style>
+        <paper-progress value="250" start="0" min="0" max="1000" class="red"></paper-progress>
+        <paper-progress value="500" start="250" min="0" max="1000" class="green"></paper-progress>
+        <paper-progress value="250" start="750" min="0" max="1000" class="blue"></paper-progress>
+      </template>
+    </demo-snippet>
   </div>
 
   <script>

--- a/paper-progress.html
+++ b/paper-progress.html
@@ -286,11 +286,21 @@ Custom property                               | Description                     
         value: false,
         reflectToAttribute: true,
         observer: '_disabledChanged'
+      },
+
+      /**
+       * A start position of the progress.
+       * When > 0 and not `indeterminate` then the indicator will be moved right
+       * by corresponding position.
+       */
+      start: {
+        type: Number,
+        value: 0
       }
     },
 
     observers: [
-      '_progressChanged(secondaryProgress, value, min, max)'
+      '_progressChanged(secondaryProgress, value, min, max, start)'
     ],
 
     hostAttributes: {
@@ -303,8 +313,13 @@ Custom property                               | Description                     
       this.toggleClass('indeterminate', indeterminate, this.$.primaryProgress);
     },
 
-    _transformProgress: function(progress, ratio) {
-      var transform = 'scaleX(' + (ratio / 100) + ')';
+    _transformProgress: function(progress, ratio, steps) {
+      if (!steps) {
+        steps = 0;
+      }
+      var transform = ' translateX(' + (steps * 100) + '%)';
+      transform += 'scaleX(' + (ratio / 100) + ')';
+
       progress.style.transform = progress.style.webkitTransform = transform;
     },
 
@@ -312,16 +327,17 @@ Custom property                               | Description                     
       this._transformProgress(this.$.primaryProgress, ratio);
     },
 
-    _progressChanged: function(secondaryProgress, value, min, max) {
+    _progressChanged: function(secondaryProgress, value, min, max, start) {
       secondaryProgress = this._clampValue(secondaryProgress);
       value = this._clampValue(value);
+      start = this._calcRatio(start);
 
       var secondaryRatio = this._calcRatio(secondaryProgress) * 100;
       var mainRatio = this._calcRatio(value) * 100;
 
       this._setSecondaryRatio(secondaryRatio);
       this._transformProgress(this.$.secondaryProgress, secondaryRatio);
-      this._transformProgress(this.$.primaryProgress, mainRatio);
+      this._transformProgress(this.$.primaryProgress, mainRatio, start);
 
       this.secondaryProgress = secondaryProgress;
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -118,6 +118,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
       });
+
+      test('set start', function(done) {
+        progress.min = 0;
+        progress.max = 100;
+        progress.value = 25;
+        progress.start = 25;
+        asyncPlatformFlush(function() {
+          var transform = progress.$.primaryProgress.style.getPropertyValue('transform');
+          var index = transform.indexOf('translateX(25%)')
+          assert.equal(index, 0, 'TranslateX not set correctly.');
+          done();
+        });
+      });
     });
 
     suite('transiting class', function() {


### PR DESCRIPTION
This Fixes #44 by adding a `start` attribute to the element. 
When this attribute is set, then the progress bar will be moved to the right by corresponding value relative to max attribute.
