### PR TITLE
Add progress container mixin

### DIFF
--- a/paper-progress.html
+++ b/paper-progress.html
@@ -70,10 +70,11 @@ The following mixins are available for styling:
 
 Custom property                                  | Description                                 | Default
 -------------------------------------------------|---------------------------------------------|--------------
-`--paper-progress-container-color`               | Mixin applied to container                  | `--google-grey-300`
+`--paper-progress-container`                     | Mixin applied to container                  | `{}`
 `--paper-progress-transition-duration`           | Duration of the transition                  | `0.008s`
 `--paper-progress-transition-timing-function`    | The timing function for the transition      | `ease`
 `--paper-progress-transition-delay`              | delay for the transition                    | `0s`
+`--paper-progress-container-color`               | Color of the container                      | `--google-grey-300`
 `--paper-progress-active-color`                  | The color of the active bar                 | `--google-green-500`
 `--paper-progress-secondary-color`               | The color of the secondary bar              | `--google-green-100`
 `--paper-progress-disabled-active-color`         | The color of the active bar if disabled     | `--google-grey-500`
@@ -98,6 +99,7 @@ Custom property                                  | Description                  
       }
 
       #progressContainer {
+        @apply(--paper-progress-container);
         position: relative;
       }
 


### PR DESCRIPTION
I needed to add some extra styles to the progress container element.  Then I discovered that unlike a lot of other paper elements, the paper-progress did not have a mixin for applying styles to the container element. This PR adds that mixin. 
