### PR TITLE
Remove "aria-valuenow" when `indeterminate` is true.

### DIFF
--- a/paper-progress.html
+++ b/paper-progress.html
@@ -303,7 +303,7 @@ Custom property                                  | Description                  
     },
 
     observers: [
-      '_progressChanged(secondaryProgress, value, min, max)'
+      '_progressChanged(secondaryProgress, value, min, max, indeterminate)'
     ],
 
     hostAttributes: {
@@ -325,7 +325,7 @@ Custom property                                  | Description                  
       this._transformProgress(this.$.primaryProgress, ratio);
     },
 
-    _progressChanged: function(secondaryProgress, value, min, max) {
+    _progressChanged: function(secondaryProgress, value, min, max, indeterminate) {
       secondaryProgress = this._clampValue(secondaryProgress);
       value = this._clampValue(value);
 
@@ -338,7 +338,11 @@ Custom property                                  | Description                  
 
       this.secondaryProgress = secondaryProgress;
 
-      this.setAttribute('aria-valuenow', value);
+      if (indeterminate) {
+        this.removeAttribute('aria-valuenow');
+      } else {
+        this.setAttribute('aria-valuenow', value);
+      }
       this.setAttribute('aria-valuemin', min);
       this.setAttribute('aria-valuemax', max);
     },

--- a/test/basic.html
+++ b/test/basic.html
@@ -118,6 +118,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
       });
+
+      test('The <paper-progress> only has a "aria-valuenow" attribute when ' +
+        '`indeterminate` is true.', function() {
+          progress.min = 0;
+          progress.max = 10;
+          progress.value = 5.1;
+          assert(progress.hasAttribute('aria-valuenow'));
+
+          progress.indeterminate = true;
+          assert(!progress.hasAttribute('aria-valuenow'));
+
+          progress.indeterminate = false;
+          assert(progress.hasAttribute('aria-valuenow'));
+        });
     });
 
     suite('transiting class', function() {


### PR DESCRIPTION
https://www.w3.org/TR/wai-aria-1.1/#progressbar

> The author should supply values for aria-valuenow, aria-valuemin, and aria-valuemax, unless the value is indeterminate, in which case the author should omit the aria-valuenow attribute.

Also, there's still an open bug about indeterminate progress bars' state being reported incorrectly to assistive software: https://crbug.com/564278 .