### PR TITLE
Use border instead of background for styling

### DIFF
--- a/paper-progress.html
+++ b/paper-progress.html
@@ -107,21 +107,18 @@ Custom property                                  | Description                  
         position: relative;
       }
 
-      #progressContainer,
-      /* the stripe for the indeterminate animation*/
-      .indeterminate::after {
-        height: var(--paper-progress-height, 4px);
+      #progressContainer::before {
+        content: "";
+        display: block;
       }
 
+      #progressContainer::before,
       #primaryProgress,
       #secondaryProgress,
-      .indeterminate::after {
-        @apply --layout-fit;
-      }
-
-      #progressContainer,
-      .indeterminate::after {
-        background: var(--paper-progress-container-color, var(--google-grey-300));
+      #progressContainer.indeterminate::after {
+        border-top-width: var(--paper-progress-height, 4px);
+        border-top-style: solid;
+        border-top-color: var(--paper-progress-container-color, var(--google-grey-300));
       }
 
       :host(.transiting) #primaryProgress,
@@ -153,29 +150,30 @@ Custom property                                  | Description                  
       }
 
       #primaryProgress {
-        background: var(--paper-progress-active-color, var(--google-green-500));
+        border-top-color: var(--paper-progress-active-color, var(--google-green-500));
       }
 
       #secondaryProgress {
-        background: var(--paper-progress-secondary-color, var(--google-green-100));
+        border-top-color: var(--paper-progress-secondary-color, var(--google-green-100));
       }
 
       :host([disabled]) #primaryProgress {
-        background: var(--paper-progress-disabled-active-color, var(--google-grey-500));
+        border-top-color: var(--paper-progress-disabled-active-color, var(--google-grey-500));
       }
 
       :host([disabled]) #secondaryProgress {
-        background: var(--paper-progress-disabled-secondary-color, var(--google-grey-300));
+        border-top-color: var(--paper-progress-disabled-secondary-color, var(--google-grey-300));
       }
 
-      :host(:not([disabled])) #primaryProgress.indeterminate {
+      :host(:not([disabled])) #progressContainer.indeterminate #primaryProgress {
         -webkit-transform-origin: right center;
         transform-origin: right center;
         -webkit-animation: indeterminate-bar var(--paper-progress-indeterminate-cycle-duration, 2s) linear infinite;
         animation: indeterminate-bar var(--paper-progress-indeterminate-cycle-duration, 2s) linear infinite;
       }
 
-      :host(:not([disabled])) #primaryProgress.indeterminate::after {
+      :host(:not([disabled])) #progressContainer.indeterminate::after {
+        @apply --layout-fit;
         content: "";
         -webkit-transform-origin: center center;
         transform-origin: center center;
@@ -313,7 +311,7 @@ Custom property                                  | Description                  
     _toggleIndeterminate: function(indeterminate) {
       // If we use attribute/class binding, the animation sometimes doesn't translate properly
       // on Safari 7.1. So instead, we toggle the class here in the update method.
-      this.toggleClass('indeterminate', indeterminate, this.$.primaryProgress);
+      this.toggleClass('indeterminate', indeterminate, this.$.progressContainer);
     },
 
     _transformProgress: function(progress, ratio) {


### PR DESCRIPTION
Fixes #57 

Note that this effectively renders the `--paper-progress-container` mixin useless - the mixin is still applied, but the background color of the slider is moved to another element (from `#progressContainer` to `#progressContainer::before`) so styling things like border radius (see #13) and inset shadow (#49) is no longer possible.